### PR TITLE
Schema.org rendering of template

### DIFF
--- a/00-lesson-00-name.md
+++ b/00-lesson-00-name.md
@@ -6,15 +6,15 @@ title: Lesson Title
 # Here you can add metadata to describe your lesson so that people and search engines can understand what it's about. Please try to use fields from the Schema.org CreativeWork type - https://schema.org/CreativeWork
 
 description:    "This is the template description. Keep me brief (2-3 sentences)"
-keywords: 	    Linear Regression, Hidden Markov 					# see: https://schema.org/keywords
-audience: 	    [PostDoc students, Early Career Researchers] 		# see: https://schema.org/audience
-license: 	    "https://creativecommons.org/licenses/by/3.0/" 		# see: schema.org/license
-author: 		[Homer Simpson, Ned Flanders] 						# see: https://schema.org/author
-contributor: 	[Barney Gumball, Dr Nick Riviera] 					# see: https://schema.org/contributor
-timeRequired: 	"1 hour" 											# see: https://schema.org/timeRequired
-learningResourceType: "lesson plan" 								# see: https://schema.org/learningResourceType
-citation: 		"How to cite a Training Material, John Smith et al, 2015" # see: https://schema.org/citation
-dateCreated: 	2016-05-01											 # see: https://schema.org/dateCreated
+keywords:       Linear Regression, Hidden Markov                # see: https://schema.org/keywords
+audience:       [PostDoc students, Early Career Researchers]    # see: https://schema.org/audience
+license:        "https://creativecommons.org/licenses/by/3.0/"  # see: schema.org/license
+author:         [Homer Simpson, Ned Flanders]                   # see: https://schema.org/author
+contributor:    [Barney Gumball, Dr Nick Riviera]               # see: https://schema.org/contributor
+timeRequired:   "1 hour"                                        # see: https://schema.org/timeRequired
+learningResourceType: "lesson plan"                             # see: https://schema.org/learningResourceType
+citation:       "How to cite a Training Material, John Smith et al, 2015" # see: https://schema.org/citation
+dateCreated:    2016-05-01                                      # see: https://schema.org/dateCreated
 ---
 
 ## Learning Objectives 

--- a/00-lesson-00-name.md
+++ b/00-lesson-00-name.md
@@ -2,7 +2,11 @@
 layout: lesson
 root: .
 title: Lesson Title
-minutes: 5
+time required: 5
+author: Homer Simpson, Ned Flanders
+description: "This is the template description. Keep me brief (2-3 sentences)"
+citation: "How to cite a Training Material, John Smith et al, 2015 (see: https://schema.org/citation)"
+licence: "https://creativecommons.org/licenses/by/3.0/ (see: schema.org/license)"
 ---
 
 ## Learning Objectives 

--- a/00-lesson-00-name.md
+++ b/00-lesson-00-name.md
@@ -2,11 +2,19 @@
 layout: lesson
 root: .
 title: Lesson Title
-time required: 5
-author: Homer Simpson, Ned Flanders
-description: "This is the template description. Keep me brief (2-3 sentences)"
-citation: "How to cite a Training Material, John Smith et al, 2015 (see: https://schema.org/citation)"
-licence: "https://creativecommons.org/licenses/by/3.0/ (see: schema.org/license)"
+
+# Here you can add metadata to describe your lesson so that people and search engines can understand what it's about. Please try to use fields from the Schema.org CreativeWork type - https://schema.org/CreativeWork
+
+description:    "This is the template description. Keep me brief (2-3 sentences)"
+keywords: 	    Linear Regression, Hidden Markov 					# see: https://schema.org/keywords
+audience: 	    [PostDoc students, Early Career Researchers] 		# see: https://schema.org/audience
+license: 	    "https://creativecommons.org/licenses/by/3.0/" 		# see: schema.org/license
+author: 		[Homer Simpson, Ned Flanders] 						# see: https://schema.org/author
+contributor: 	[Barney Gumball, Dr Nick Riviera] 					# see: https://schema.org/contributor
+timeRequired: 	"1 hour" 											# see: https://schema.org/timeRequired
+learningResourceType: "lesson plan" 								# see: https://schema.org/learningResourceType
+citation: 		"How to cite a Training Material, John Smith et al, 2015" # see: https://schema.org/citation
+dateCreated: 	2016-05-01											 # see: https://schema.org/dateCreated
 ---
 
 ## Learning Objectives 

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -1,4 +1,3 @@
-
 ---
 ---
 <!DOCTYPE html>
@@ -20,7 +19,6 @@
        "@type": "creativeWork",
        "genre": "trainingMaterial",
        "name": "{{page.title}}",
-       "url": "{{page.url}}",
        "description": "{{page.description}}",
        "license": "{{page.licence}}",
        "citation": "{{page.citation}}",
@@ -39,13 +37,13 @@
 
       <div class="row-fluid">
         <div class="span10 offset1">
- <!-- start content -->
+          <!-- start content -->
           {% if page.title %}
           <h1>{{page.title}}</h1>
           {% endif %}
           {{content}}
- <!-- end content -->
-</div>
+          <!-- end content -->
+        </div>
       </div>
 
       {% include footer.html %}

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -20,14 +20,33 @@
        "genre": "trainingMaterial",
        "name": "{{page.title}}",
        "description": "{{page.description}}",
+       "keywords": "{{page.keywords}}",
+       "audience": [
+          {% for audience in page.audience %}{
+           "@type": "Audience",
+           "name": "{{audience}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+       ],
        "license": "{{page.licence}}",
-       "citation": "{{page.citation}}",
-       "author": {
+       "author": [
+         {% for author in page.author %}{
            "@type": "Person",
-           "name": "{{page.author}}"
-       },
-       "timeRequired": "{{page.minutes}}",
-       "learningResourceType": "{{page.learning_resource_type}}"
+           "name": "{{author}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+      ],
+       "contributor": [
+         {% for contributor in page.contributor %}{
+           "@type": "Person",
+           "name": "{{contributor}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+      ],
+       "timeRequired": "{{page.timeRequired}}",
+       "learningResourceType": "{{page.learningResourceType}}",
+       "citation": "{{page.citation}}",
+       "dateCreated" : "{{page.dateCreated}}"
     }
     </script>
     <!-- end of schema.org annotations -->

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -1,3 +1,4 @@
+
 ---
 ---
 <!DOCTYPE html>
@@ -10,18 +11,41 @@
     <link rel="stylesheet" type="text/css" href="{{page.root}}/css/lesson.css" />
   </head>
   <body>
+    <!-- Schema.org annotations in JSON-LD for a CreativeWork type.
+         Variables should be declared in the .md file 
+         For full list of available attributes see https://schema.org/CreativeWork -->
+    <script type="application/ld+json">
+    {
+       "@context": "http://schema.org/",
+       "@type": "creativeWork",
+       "genre": "trainingMaterial",
+       "name": "{{page.title}}",
+       "url": "{{page.url}}",
+       "description": "{{page.description}}",
+       "license": "{{page.licence}}",
+       "citation": "{{page.citation}}",
+       "author": {
+           "@type": "Person",
+           "name": "{{page.author}}"
+       },
+       "timeRequired": "{{page.minutes}}",
+       "learningResourceType": "{{page.learning_resource_type}}"
+    }
+    </script>
+    <!-- end of schema.org annotations -->
+
     <div class="container">
       {% include banner.html %}
 
       <div class="row-fluid">
         <div class="span10 offset1">
-	  <!-- start content -->
+ <!-- start content -->
           {% if page.title %}
           <h1>{{page.title}}</h1>
           {% endif %}
           {{content}}
-	  <!-- end content -->
-	</div>
+ <!-- end content -->
+</div>
       </div>
 
       {% include footer.html %}


### PR DESCRIPTION
Hi,

I thought it might be a good idea to help the discoverability of training materials by having more metadata examples in the markdown, and by rendering the metadata into a [schema.org CreativeWork specification](schema.org/CreativeWork) using the JSON-LD representation.

If you think it's a good idea and accept the request, I can go about updating the existing Data Carpentry materials and format them similarly. 

Structuring metadata using Schema.org is very useful for SEO to get included in more Google SERPs; as well as for content integration platforms like [TeSS - The Life Science Training Portal](tess.elixir-uk.org). There's more about it on the working group page for [BioSchemas](bioschemas.org)
